### PR TITLE
V3.10.3 atbay patch support redis lock username and limit connections

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -46,7 +46,7 @@ ext {
     revProtogenAnnotations = '1.0.0'
     revProtogenCodegen = '1.4.0'
     revRarefiedRedis = '0.0.17'
-    revRedisson = '3.13.3'
+    revRedisson = '3.20.0'
     revRxJava = '1.2.2'
     revSpectator = '0.122.0'
     revSpock = '1.3-groovy-2.5'

--- a/redis-lock/dependencies.lock
+++ b/redis-lock/dependencies.lock
@@ -27,7 +27,7 @@
             "locked": "2.17.1"
         },
         "org.redisson:redisson": {
-            "locked": "3.13.3"
+            "locked": "3.20.0"
         },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "2.7.2"
@@ -185,7 +185,7 @@
             "locked": "2.17.1"
         },
         "org.redisson:redisson": {
-            "locked": "3.13.3"
+            "locked": "3.20.0"
         }
     },
     "testCompileClasspath": {
@@ -220,7 +220,7 @@
             "locked": "5.8.2"
         },
         "org.redisson:redisson": {
-            "locked": "3.13.3"
+            "locked": "3.20.0"
         },
         "org.springframework.boot:spring-boot-starter-log4j2": {
             "locked": "2.7.2"
@@ -390,7 +390,7 @@
             "locked": "5.8.2"
         },
         "org.redisson:redisson": {
-            "locked": "3.13.3"
+            "locked": "3.20.0"
         },
         "org.springframework.boot:spring-boot-starter-log4j2": {
             "locked": "2.7.2"

--- a/redis-lock/src/main/java/com/netflix/conductor/redislock/config/RedisLockConfiguration.java
+++ b/redis-lock/src/main/java/com/netflix/conductor/redislock/config/RedisLockConfiguration.java
@@ -16,6 +16,7 @@ import java.util.Arrays;
 
 import org.redisson.Redisson;
 import org.redisson.config.Config;
+import org.redisson.connection.SequentialDnsAddressResolverFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -49,6 +50,11 @@ public class RedisLockConfiguration {
             throw new RuntimeException(message, ie);
         }
         String redisServerAddress = properties.getServerAddress();
+        int sequentialDnsResolverBulkSize = properties.getSequentialDnsResolverBulkSize();
+        int slaveConnectionMinimumIdleSize = properties.getSlaveConnectionMinimumIdleSize();
+        int slaveConnectionPoolSize = properties.getMasterConnectionPoolSize();
+        int masterConnectionMinimumIdleSize = properties.getMasterConnectionMinimumIdleSize();
+        int masterConnectionPoolSize = properties.getMasterConnectionPoolSize();
         String redisServerUsername = properties.getServerUsername();
         String redisServerPassword = properties.getServerPassword();
         String masterName = properties.getServerMasterName();
@@ -65,8 +71,15 @@ public class RedisLockConfiguration {
                         .setTimeout(connectionTimeout);
                 break;
             case CLUSTER:
+                SequentialDnsAddressResolverFactory sequentialDnsResolver =
+                        new SequentialDnsAddressResolverFactory(sequentialDnsResolverBulkSize);
                 redisConfig
+                        .setAddressResolverGroupFactory(sequentialDnsResolver)
                         .useClusterServers()
+                        .setSlaveConnectionMinimumIdleSize(slaveConnectionMinimumIdleSize)
+                        .setSlaveConnectionPoolSize(slaveConnectionPoolSize)
+                        .setMasterConnectionMinimumIdleSize(masterConnectionMinimumIdleSize)
+                        .setMasterConnectionPoolSize(masterConnectionPoolSize)
                         .setScanInterval(2000) // cluster state scan interval in milliseconds
                         .addNodeAddress(redisServerAddress.split(","))
                         .setUsername(redisServerUsername)

--- a/redis-lock/src/main/java/com/netflix/conductor/redislock/config/RedisLockConfiguration.java
+++ b/redis-lock/src/main/java/com/netflix/conductor/redislock/config/RedisLockConfiguration.java
@@ -49,6 +49,7 @@ public class RedisLockConfiguration {
             throw new RuntimeException(message, ie);
         }
         String redisServerAddress = properties.getServerAddress();
+        String redisServerUsername = properties.getServerUsername();
         String redisServerPassword = properties.getServerPassword();
         String masterName = properties.getServerMasterName();
 
@@ -68,6 +69,7 @@ public class RedisLockConfiguration {
                         .useClusterServers()
                         .setScanInterval(2000) // cluster state scan interval in milliseconds
                         .addNodeAddress(redisServerAddress.split(","))
+                        .setUsername(redisServerUsername)
                         .setPassword(redisServerPassword)
                         .setTimeout(connectionTimeout);
                 break;

--- a/redis-lock/src/main/java/com/netflix/conductor/redislock/config/RedisLockProperties.java
+++ b/redis-lock/src/main/java/com/netflix/conductor/redislock/config/RedisLockProperties.java
@@ -23,6 +23,9 @@ public class RedisLockProperties {
     /** The address of the redis server following format -- host:port */
     private String serverAddress = "redis://127.0.0.1:6379";
 
+    /** The username for redis authentication */
+    private String serverUsername = null;
+
     /** The password for redis authentication */
     private String serverPassword = null;
 
@@ -52,6 +55,14 @@ public class RedisLockProperties {
 
     public void setServerAddress(String serverAddress) {
         this.serverAddress = serverAddress;
+    }
+
+    public String getServerUsername() {
+        return serverUsername;
+    }
+
+    public void setServerUsername(String serverUsername) {
+        this.serverUsername = serverUsername;
     }
 
     public String getServerPassword() {

--- a/redis-lock/src/main/java/com/netflix/conductor/redislock/config/RedisLockProperties.java
+++ b/redis-lock/src/main/java/com/netflix/conductor/redislock/config/RedisLockProperties.java
@@ -23,6 +23,21 @@ public class RedisLockProperties {
     /** The address of the redis server following format -- host:port */
     private String serverAddress = "redis://127.0.0.1:6379";
 
+    /** Size of parallel resolution of dns address in each sequential dns resolution bulk */
+    private int sequentialDnsResolverBulkSize = 8;
+
+    /** Initial connections number issued to slave nodes */
+    private int slaveConnectionMinimumIdleSize = 4;
+
+    /** connections pool max size issued to slave nodes */
+    private int slaveConnectionPoolSize = 8;
+
+    /** Initial connections number issued to master nodes */
+    private int masterConnectionMinimumIdleSize = 4;
+
+    /** connections pool max size issued to master nodes */
+    private int masterConnectionPoolSize = 8;
+
     /** The username for redis authentication */
     private String serverUsername = null;
 
@@ -55,6 +70,46 @@ public class RedisLockProperties {
 
     public void setServerAddress(String serverAddress) {
         this.serverAddress = serverAddress;
+    }
+
+    public int getSequentialDnsResolverBulkSize() {
+        return sequentialDnsResolverBulkSize;
+    }
+
+    public void setSequentialDnsResolverBulkSize(int sequentialDnsResolverBulkSize) {
+        this.sequentialDnsResolverBulkSize = sequentialDnsResolverBulkSize;
+    }
+
+    public int getSlaveConnectionMinimumIdleSize() {
+        return slaveConnectionMinimumIdleSize;
+    }
+
+    public void setSlaveConnectionMinimumIdleSize(int slaveConnectionMinimumIdleSize) {
+        this.slaveConnectionMinimumIdleSize = slaveConnectionMinimumIdleSize;
+    }
+
+    public int getSlaveConnectionPoolSize() {
+        return slaveConnectionPoolSize;
+    }
+
+    public void setSlaveConnectionPoolSize(int slaveConnectionPoolSize) {
+        this.slaveConnectionPoolSize = slaveConnectionPoolSize;
+    }
+
+    public int getMasterConnectionMinimumIdleSize() {
+        return masterConnectionMinimumIdleSize;
+    }
+
+    public void setMasterConnectionMinimumIdleSize(int masterConnectionMinimumIdleSize) {
+        this.masterConnectionMinimumIdleSize = masterConnectionMinimumIdleSize;
+    }
+
+    public int getMasterConnectionPoolSize() {
+        return masterConnectionPoolSize;
+    }
+
+    public void setMasterConnectionPoolSize(int masterConnectionPoolSize) {
+        this.masterConnectionPoolSize = masterConnectionPoolSize;
     }
 
     public String getServerUsername() {

--- a/server/dependencies.lock
+++ b/server/dependencies.lock
@@ -479,7 +479,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-redis-lock"
             ],
-            "locked": "3.13.3"
+            "locked": "3.20.0"
         },
         "org.springdoc:springdoc-openapi-ui": {
             "firstLevelTransitive": [
@@ -917,7 +917,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-redis-lock"
             ],
-            "locked": "3.13.3"
+            "locked": "3.20.0"
         },
         "org.springdoc:springdoc-openapi-ui": {
             "firstLevelTransitive": [
@@ -1462,7 +1462,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-redis-lock"
             ],
-            "locked": "3.13.3"
+            "locked": "3.20.0"
         },
         "org.springdoc:springdoc-openapi-ui": {
             "firstLevelTransitive": [

--- a/test-harness/dependencies.lock
+++ b/test-harness/dependencies.lock
@@ -673,7 +673,7 @@
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-redis-lock"
             ],
-            "locked": "3.13.3"
+            "locked": "3.20.0"
         },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [


### PR DESCRIPTION
Pull Request type
----
- [ ] Bugfix
- [ V] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew generateLock saveLock` to refresh dependencies)
- [ ] WHOSUSING.md
- [ ] Other (please describe):

Changes in this PR
----

Supported redis-lock username and added connections control mechanism for redis-lock

